### PR TITLE
Improve UI design

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,9 +8,12 @@ export default function App() {
   const store = useLocalStore()
   return (
     <BrowserRouter>
-      <nav className="p-4 bg-gray-800 text-white flex gap-4">
-        <Link to="/" className="hover:underline">首页</Link>
-        <Link to="/fav" className="hover:underline">收藏</Link>
+      <nav className="p-4 bg-gradient-to-r from-indigo-600 via-purple-600 to-pink-500 text-white">
+        <div className="max-w-3xl mx-auto flex items-center gap-4">
+          <Link to="/" className="font-semibold text-lg mr-auto">Interview Deck</Link>
+          <Link to="/" className="hover:underline">首页</Link>
+          <Link to="/fav" className="hover:underline">收藏</Link>
+        </div>
       </nav>
       <Routes>
         <Route path="/" element={<Home store={store} />} />

--- a/client/src/components/QuestionCard.jsx
+++ b/client/src/components/QuestionCard.jsx
@@ -18,7 +18,7 @@ export default function QuestionCard({ q, store }) {
   }
 
   return (
-    <div className="bg-white shadow rounded p-4 mb-4">
+    <div className="bg-white border border-gray-200 shadow rounded-lg p-4 mb-4 transition-shadow hover:shadow-lg">
       <div className="flex justify-between items-start">
         <h3 className="font-semibold text-lg">{q.question}</h3>
         <button onClick={() => store.toggleFavorite(q.id)}>
@@ -26,10 +26,12 @@ export default function QuestionCard({ q, store }) {
         </button>
       </div>
       <div className="text-sm text-gray-500 mb-2">分类：{q.category}</div>
-      <button className="text-blue-500 mb-2" onClick={() => setShowAnswer(v => !v)}>
+      <button className="text-blue-600 mb-2" onClick={() => setShowAnswer(v => !v)}>
         {showAnswer ? '隐藏答案' : '查看答案'}
       </button>
-      {showAnswer && <p className="mb-2">{q.answer}</p>}
+      {showAnswer && (
+        <p className="mb-2 text-gray-700 transition-opacity duration-300">{q.answer}</p>
+      )}
       <textarea
         className="w-full border rounded p-2 mb-2 text-sm"
         placeholder="个人笔记"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,12 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  background: linear-gradient(to bottom right, #f8fafc, #e2e8f0);
+  min-height: 100vh;
+  color: #1f2937; /* gray-800 */
+  font-family: 'Inter', sans-serif;
+}

--- a/client/src/pages/Favorites.jsx
+++ b/client/src/pages/Favorites.jsx
@@ -4,8 +4,8 @@ import QuestionCard from '../components/QuestionCard'
 export default function Favorites({ store }) {
   const list = questions.filter(q => store.favorites.includes(q.id))
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">收藏的题目</h1>
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-3xl font-semibold mb-4">收藏的题目</h1>
       {list.length === 0 && <p>暂无收藏</p>}
       {list.map(q => (
         <QuestionCard key={q.id} q={q} store={store} />

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -15,8 +15,8 @@ export default function Home({ store }) {
   })
 
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">面试知识卡片库</h1>
+    <div className="p-4 max-w-3xl mx-auto">
+      <h1 className="text-3xl font-semibold mb-4">面试知识卡片库</h1>
       <div className="mb-4 flex flex-wrap gap-2 items-center">
         <input
           className="border rounded p-2 flex-1 min-w-40"


### PR DESCRIPTION
## Summary
- modernize navigation bar with gradient color
- center content containers on home and favorites pages
- enhance question card appearance
- use Google font and gradient background

## Testing
- `npm run build`
- `npm run lint`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68429654460483258c88034917d257a5