### PR TITLE
Implement authentication and Google-style theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,9 @@ npm install
 npm start
 ```
 
-The server exposes a single endpoint `/api/questions` which returns the list of interview questions as JSON.
+The server exposes several endpoints:
+
+- `POST /api/register` – register a new user
+- `POST /api/login` – authenticate and receive a token
+- `GET /api/questions` – returns the list of interview questions as JSON
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,8 @@ import { AppBar, Toolbar, Typography, Button, Container } from '@mui/material'
 import { useLocalStore } from './hooks/useLocalStore'
 import Home from './pages/Home'
 import Favorites from './pages/Favorites'
+import Login from './pages/Login'
+import Register from './pages/Register'
 import './App.css'
 
 export default function App() {
@@ -25,12 +27,28 @@ export default function App() {
           <Button color="inherit" component={RouterLink} to="/fav">
             收藏
           </Button>
+          {store.token ? (
+            <Button color="inherit" onClick={store.logout}>
+              退出
+            </Button>
+          ) : (
+            <>
+              <Button color="inherit" component={RouterLink} to="/login">
+                登录
+              </Button>
+              <Button color="inherit" component={RouterLink} to="/register">
+                注册
+              </Button>
+            </>
+          )}
         </Toolbar>
       </AppBar>
       <Container maxWidth="md" sx={{ mt: 2 }}>
         <Routes>
           <Route path="/" element={<Home store={store} />} />
           <Route path="/fav" element={<Favorites store={store} />} />
+          <Route path="/login" element={<Login store={store} />} />
+          <Route path="/register" element={<Register />} />
         </Routes>
       </Container>
     </BrowserRouter>

--- a/client/src/hooks/useLocalStore.js
+++ b/client/src/hooks/useLocalStore.js
@@ -38,12 +38,23 @@ export function useLocalStore() {
     setStore(prev => ({ ...prev, status: { ...(prev.status || {}), [id]: status } }))
   }, [])
 
+  const setToken = useCallback(token => {
+    setStore(prev => ({ ...prev, token }))
+  }, [])
+
+  const logout = useCallback(() => {
+    setStore(prev => ({ ...prev, token: null }))
+  }, [])
+
   return {
     favorites: store.favorites || [],
     notes: store.notes || {},
     status: store.status || {},
+    token: store.token || null,
     toggleFavorite,
     setNote,
     setStatus,
+    setToken,
+    logout,
   }
 }

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -9,6 +9,12 @@ const theme = createTheme({
     background: {
       default: '#f1f3f4',
     },
+    primary: {
+      main: '#4285F4',
+    },
+    secondary: {
+      main: '#DB4437',
+    },
   },
   typography: {
     fontFamily: ['Roboto', 'Inter', 'sans-serif'].join(','),

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+import { Box, Button, TextField, Typography, Alert } from '@mui/material'
+
+export default function Login({ store }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async e => {
+    e.preventDefault()
+    setError('')
+    try {
+      const res = await fetch('http://localhost:3000/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Login failed')
+      store.setToken(data.token)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ maxWidth: 360, mx: 'auto', mt: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h4" textAlign="center">登录</Typography>
+      {error && <Alert severity="error">{error}</Alert>}
+      <TextField label="用户名" value={username} onChange={e => setUsername(e.target.value)} required />
+      <TextField label="密码" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+      <Button variant="contained" type="submit">登录</Button>
+    </Box>
+  )
+}

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import { Box, Button, TextField, Typography, Alert } from '@mui/material'
+
+export default function Register() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async e => {
+    e.preventDefault()
+    setError('')
+    setMessage('')
+    if (password !== confirm) {
+      setError('密码不一致')
+      return
+    }
+    try {
+      const res = await fetch('http://localhost:3000/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Register failed')
+      setMessage('注册成功，请登录')
+      setUsername('')
+      setPassword('')
+      setConfirm('')
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ maxWidth: 360, mx: 'auto', mt: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <Typography variant="h4" textAlign="center">注册</Typography>
+      {message && <Alert severity="success">{message}</Alert>}
+      {error && <Alert severity="error">{error}</Alert>}
+      <TextField label="用户名" value={username} onChange={e => setUsername(e.target.value)} required />
+      <TextField label="密码" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+      <TextField label="确认密码" type="password" value={confirm} onChange={e => setConfirm(e.target.value)} required />
+      <Button variant="contained" type="submit">注册</Button>
+    </Box>
+  )
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,37 @@
 import express from 'express'
+import cors from 'cors'
 import { questions } from './questions.js'
 
 const app = express()
 const PORT = process.env.PORT || 3000
+
+// Middleware
+app.use(cors())
+app.use(express.json())
+
+// In-memory user store
+const users = new Map()
+
+app.post('/api/register', (req, res) => {
+  const { username, password } = req.body
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing username or password' })
+  }
+  if (users.has(username)) {
+    return res.status(400).json({ error: 'User already exists' })
+  }
+  users.set(username, { password })
+  res.json({ success: true })
+})
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body
+  const user = users.get(username)
+  if (!user || user.password !== password) {
+    return res.status(401).json({ error: 'Invalid credentials' })
+  }
+  res.json({ token: `token-${username}` })
+})
 
 app.get('/api/questions', (req, res) => {
   res.json(questions)

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "server",
       "version": "0.1.0",
       "dependencies": {
+        "cors": "^2.8.5",
         "express": "^4.19.2"
       },
       "devDependencies": {
@@ -220,6 +221,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -790,6 +804,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "dev": "nodemon index.js"
   },
   "dependencies": {
-    "express": "^4.19.2"
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "nodemon": "^3.1.0"


### PR DESCRIPTION
## Summary
- add login and registration pages
- support auth token in local storage
- expose `/api/login` and `/api/register` endpoints
- add CORS and JSON parsing middleware
- update theme colors to Google palette
- document API endpoints

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` in `client` *(fails: Missing script)*
- `npm test` in `server` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68429d9653848325a5b10bd3171ab2f5